### PR TITLE
Added support for non-windows linebreaks

### DIFF
--- a/src/BBCodeParser.php
+++ b/src/BBCodeParser.php
@@ -109,7 +109,7 @@ class BBCodeParser
             'content' => '$1'
         ],
         'linebreak' => [
-            'pattern' => '/\r\n/',
+            'pattern' => '/\r?\n/',
             'replace' => '<br />',
             'content' => ''
         ]


### PR DESCRIPTION
Most of the time you just get \n, even if you submit text from a Windows PC it seems to end up as \n instead of \r\n for me.

But this change will permit both. I double-checked that it wouldn't replace the \n on its own first, and it doesn't. It checks \r\n then \n
